### PR TITLE
Add support to clear command line using Ctrl+C

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -4,6 +4,7 @@ import Styles from './styles';
 
 const CTRL_CHAR_CODE = 17;
 const L_CHAR_CODE = 76;
+const C_CHAR_CODE = 67;
 const UP_CHAR_CODE = 38;
 const DOWN_CHAR_CODE = 40;
 const TAB_CHAR_CODE = 9;
@@ -67,6 +68,7 @@ export default class Terminal extends Component {
      *
      * -- Supported hot keys --
      * ctrl + l : clear
+     * ctrl + c : cancel current command
      * up - prev command from history
      * down - next command from history
      * tab - autocomplete
@@ -75,6 +77,10 @@ export default class Terminal extends Component {
         if (evt.which === L_CHAR_CODE) {
             if (this.ctrlPressed) {
                 this.setState(this.Bash.execute('clear', this.state));
+            }
+        } else if (evt.which === C_CHAR_CODE) {
+            if (this.ctrlPressed) {
+                this.refs.input.value = '';
             }
         } else if (evt.which === UP_CHAR_CODE) {
             if (this.Bash.hasPrevCommand()) {

--- a/tests/component.js
+++ b/tests/component.js
@@ -110,6 +110,21 @@ describe('ReactBash component', () => {
             chai.assert.strictEqual(wrapper.state().history.length, 1);
         });
 
+        it('should clear command line on ctrl + c', () => {
+            const expected = '';
+            instance.refs.input.value = 'help';
+            wrapper.find('input').simulate('keydown', keyEvent(17));
+            wrapper.find('input').simulate('keyup', keyEvent(67));
+            chai.assert.strictEqual(instance.refs.input.value, expected);
+        });
+
+        it('should not clear command line on only c', () => {
+            const expected = 'help';
+            instance.refs.input.value = expected;
+            wrapper.find('input').simulate('keyup', keyEvent(67));
+            chai.assert.strictEqual(instance.refs.input.value, expected);
+        });
+
         it('should handle the up arrow', () => {
             sinon.stub(instance.Bash, 'hasPrevCommand').returns(true);
             sinon.stub(instance.Bash, 'getPrevCommand').returns('Foo');


### PR DESCRIPTION
Following some of bash's default keybindings, this PR adds support for clearing current command line using <kbd>Ctrl</kbd>+<kbd>C</kbd> key stroke.