### PR TITLE
Updating autocomplete to branch for commands vs. paths

### DIFF
--- a/src/bash.js
+++ b/src/bash.js
@@ -60,31 +60,37 @@ export default class Bash {
         return { command, args };
     }
 
-    autocomplete(token, { structure, cwd }) {
-        // Autocomplete paths
-        let partialPath;
-        let path = cwd;
-        if (token.includes('/')) {
+    /*
+     * This is a very naive autocomplete method that works for both
+     * commands and directories. If the input contains only one token it
+     * should only suggest commands.
+     *
+     * @param {string} input - the user input
+     * @param {Object} state - the terminal state
+     * @param {Object} state.structure - the file structure
+     * @param {string} state.cwd - the current working directory
+     *
+     * @returns {?string} a suggested autocomplete for the <input>
+     */
+    autocomplete(input, { structure, cwd }) {
+        const tokens = input.split(/ +/);
+        let token = tokens.pop();
+        const filter = item => item.indexOf(token) === 0;
+        const result = str => tokens.concat(str).join(' ');
+
+        if (tokens.length === 0) {
+            const suggestions = Object.keys(this.commands).filter(filter);
+            return suggestions.length === 1 ? result(suggestions[0]) : null;
+        } else {
             const pathList = token.split('/');
             token = pathList.pop();
-            partialPath = pathList.join('/');
-            path = Util.extractPath(partialPath, cwd);
-        }
-
-        const { err, dir } = Util.getDirectoryByPath(structure, path);
-        if (err) return null;
-
-        // Don't include commands in path autocompletes
-        let potentialItems = Object.keys(dir);
-        if (path === cwd) {
-            potentialItems = potentialItems.concat(Object.keys(this.commands));
-        }
-
-        const items = potentialItems.filter(item => item.indexOf(token) === 0);
-        if (items.length === 1) {
-            return path !== cwd ? `${partialPath}/${items[0]}` : items[0];
-        } else {
-            return null;
+            const partialPath = pathList.join('/');
+            const path = Util.extractPath(partialPath, cwd);
+            const { err, dir } = Util.getDirectoryByPath(structure, path);
+            if (err) return null;
+            const suggestions = Object.keys(dir).filter(filter);
+            const prefix = partialPath ? `${partialPath}/` : '';
+            return suggestions.length === 1 ? result(`${prefix}${suggestions[0]}`) : null;
         }
     }
 

--- a/src/component.js
+++ b/src/component.js
@@ -54,10 +54,10 @@ export default class Terminal extends Component {
      * update the input.
      */
     attemptAutocomplete() {
-        const tokens = this.refs.input.value.split(/ +/);
-        const command = this.Bash.autocomplete(tokens.pop(), this.state);
-        if (command) {
-            this.refs.input.value = tokens.concat(command).join(' ');
+        const input = this.refs.input.value;
+        const suggestion = this.Bash.autocomplete(input, this.state);
+        if (suggestion) {
+            this.refs.input.value = suggestion;
         }
     }
 

--- a/tests/bash.js
+++ b/tests/bash.js
@@ -199,40 +199,52 @@ describe('bash class methods', () => {
             chai.assert.isFunction(bash.autocomplete);
         });
 
-        it('should autocomplete a directory name', () => {
-            const expected = 'dir1';
-            const actual = bash.autocomplete('di', mockState);
-            chai.assert.strictEqual(expected, actual);
-        });
-
-        it('should autocomplete a file name', () => {
-            const expected = 'file1';
-            const actual = bash.autocomplete('fil', mockState);
-            chai.assert.strictEqual(expected, actual);
-        });
-
         it('should autocomplete a command', () => {
             const expected = 'help';
             const actual = bash.autocomplete('he', mockState);
             chai.assert.strictEqual(expected, actual);
         });
 
+        it('should not autocomplete a path if input has only one token', () => {
+            const expected = null;
+            const actual = bash.autocomplete('dir', mockState);
+            chai.assert.strictEqual(expected, actual);
+        });
+
+        it('should not autocomplete a command if input has more than one token', () => {
+            const expected = null;
+            const actual = bash.autocomplete('ls he', mockState);
+            chai.assert.strictEqual(expected, actual);
+        });
+
+        it('should autocomplete a directory name', () => {
+            const expected = 'ls dir1';
+            const actual = bash.autocomplete('ls di', mockState);
+            chai.assert.strictEqual(expected, actual);
+        });
+
+        it('should autocomplete a file name', () => {
+            const expected = 'ls file1';
+            const actual = bash.autocomplete('ls fil', mockState);
+            chai.assert.strictEqual(expected, actual);
+        });
+
         it('should autocomplete a path', () => {
-            const expected = 'dir1/childDir';
-            const actual = bash.autocomplete('dir1/chi', mockState);
+            const expected = 'ls dir1/childDir';
+            const actual = bash.autocomplete('ls dir1/chi', mockState);
             chai.assert.strictEqual(expected, actual);
         });
 
         it('should not autocomplete commands on paths', () => {
             const expected = null;
-            const actual = bash.autocomplete('dir1/clea', mockState);
+            const actual = bash.autocomplete('ls dir1/clea', mockState);
             chai.assert.strictEqual(expected, actual);
         });
 
         it('should autocomplete a path with .. in it', () => {
-            const expected = '../../dir1';
+            const expected = 'ls ../../dir1';
             const state = Object.assign({}, mockState, { cwd: 'dir1/childDir' });
-            const actual = bash.autocomplete('../../dir', state);
+            const actual = bash.autocomplete('ls ../../dir', state);
             chai.assert.strictEqual(expected, actual);
         });
 


### PR DESCRIPTION
#7 

The current autocomplete always included `commands` in the `potentialItems` list. This fixes it to fork based on token length. If there is only one token it should autocomplete a command name, otherwise it should look for paths to autocomplete.