### PR TITLE
Refactoring arg parsing to better handle flags and multiple commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ const extensions = { clear };
 <Terminal extensions={extensions} />
 ```
 
-Each command is given the `state` and a parsed `args` object. Some commands can use optional or required arguments. ReactBash uses the [yargs](https://www.npmjs.com/package/yargs) approach. There are three types of arguments: `anonymous` args, `boolean` args (--), and `named` args (-). You can also alias commands for shorthands or multiple ways of writing the same argument (see the ls command for an example). To see how ReactBash parses the input, check out this fictional example that utilizes all three in order.
+Each command is given the `state` and a parsed `args` object. Some commands can use optional or required arguments. There are three types of arguments: `anonymous` args, `named` args (--), and `flag` args (-). To see how ReactBash parses the input, check out this fictional example that utilizes all three in order.
 
-For the input `foo some/path --bar -hello world`, ReactBash would parse the input as:
+For the input `foo some/path -baz --hello world`, ReactBash would parse the input as:
 ```js
 command = 'foo'
 args = {
     0: 'some/path',
-    bar: true,
-    hello: 'world'
+    hello: 'world',
+    flags: { b: true, a: true, z: true },
 }
 ```
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -22,12 +22,6 @@ export const clear = {
 };
 
 export const ls = {
-    aliases: {
-        '-l': '--long',
-        '-la': ['--long', '--all'],
-        '-al': ['--long', '--all'],
-        '-a': '--all',
-    },
     exec: (state, args) => {
         const { history, structure, cwd } = state;
         const path = args[0] || '';
@@ -35,13 +29,13 @@ export const ls = {
         const { err, dir } = Util.getDirectoryByPath(structure, fullPath);
 
         if (err) {
-            return Util.reportError(state, err, path);
+            return Util.appendError(state, err, path);
         } else {
             let content = Object.keys(dir);
-            if (!args.all) {
+            if (!args.flags.a) {
                 content = content.filter(name => name[0] !== '.');
             }
-            if (args.long) {
+            if (args.flags.l) {
                 return { structure, cwd,
                     history: history.concat(content.map(value => {
                         return { value };
@@ -65,11 +59,11 @@ export const cat = {
         const fullPath = Util.extractPath(relativePath.join('/'), cwd);
         const { err, dir } = Util.getDirectoryByPath(structure, fullPath);
         if (err) {
-            return Util.reportError(state, err, path);
+            return Util.appendError(state, err, path);
         } else if (!dir[fileName]) {
-            return Util.reportError(state, Errors.NO_SUCH_FILE, path);
+            return Util.appendError(state, Errors.NO_SUCH_FILE, path);
         } else if (!dir[fileName].hasOwnProperty('content')) {
-            return Util.reportError(state, Errors.IS_A_DIRECTORY, path);
+            return Util.appendError(state, Errors.IS_A_DIRECTORY, path);
         } else {
             return { cwd, structure,
                 history: history.concat({
@@ -91,7 +85,7 @@ export const mkdir = {
         const { dir } = Util.getDirectoryByPath(deepCopy, fullPath);
 
         if (dir[newDirectory]) {
-            return Util.reportError(state, Errors.FILE_EXISTS, path);
+            return Util.appendError(state, Errors.FILE_EXISTS, path);
         } else {
             dir[newDirectory] = {};
             return { cwd, history, structure: deepCopy };
@@ -111,7 +105,7 @@ export const cd = {
         const { err } = Util.getDirectoryByPath(structure, fullPath);
 
         if (err) {
-            return Util.reportError(state, err, path);
+            return Util.appendError(state, err, path);
         } else {
             return { history, structure, cwd: fullPath };
         }

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,0 +1,60 @@
+/*
+ * This method parses a single command + args. It handles
+ * the tokenization and processing of flags, anonymous args,
+ * and named args.
+ *
+ * @param {string} input - the user input to parse
+ * @returns {Object} the parsed command/arg dataf84t56y78ju7y6f
+ */
+export function parseInput(input) {
+    const tokens = input.split(/ +/);
+    const command = tokens.shift();
+    const args = { flags: {} };
+    let anonArgPos = 0;
+
+    while (tokens.length > 0) {
+        const token = tokens.shift();
+        if (token[0] === '-') {
+            if (token[1] === '-') {
+                const next = tokens.shift();
+                args[token.slice(2)] = next;
+            } else {
+                const flags = token.slice(1).split('');
+                flags.forEach(flag => {
+                    args.flags[flag] = true;
+                });
+            }
+        } else {
+            args[anonArgPos++] = token;
+        }
+    }
+    return { command, args };
+}
+
+/*
+ * This function splits the input by `&&`` creating a
+ * dependency chain. The chain consists of a list of
+ * other commands to be run.
+ *
+ * @param {string} input - the user input
+ * @returns {Array} a list of lists of command/arg pairs
+ *
+ * Example: `cd dir1; cat file.txt && pwd`
+ * In this example `pwd` should only be run if dir/file.txt
+ * is a readable file. The corresponding response would look
+ * like this, where the outer list is the dependent lists..
+ *
+ * [
+ *   [
+ *     { command: 'cd', args: { 0: 'dir1'} },
+ *     { command: 'cat', args: { 0: 'file.txt'} }
+ *   ],
+ *   [
+ *     { command: 'pwd' }
+ *   ]
+ * ]
+ */
+export function parse(inputs) {
+    return inputs.trim().split(/ *&& */)
+        .map(deps => deps.split(/ *; */).map(parseInput));
+}

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,13 @@
 import { Errors, BACK_REGEX } from './const';
 
+/*
+ * This is a utility method for trimming the beginning
+ * and ending of a string of any given char.
+ *
+ * @param {string} str - the string the trim
+ * @param {string} char - the char to remove
+ * @returns {string} the trimmed string
+ */
 export function trim(str, char) {
     if (str[0] === char) {
         str = str.substr(1);
@@ -10,8 +18,18 @@ export function trim(str, char) {
     return str;
 }
 
-export function reportError(state, error, command) {
+/*
+ * This is a utility method for appending an error
+ * message to the current state.
+ *
+ * @param {Object} state - the terminal state
+ * @param {string} error - the error to interpolate
+ * @param {string} command - the string to insert
+ * @returns {Object} the new terminal state
+ */
+export function appendError(state, error, command) {
     return Object.assign({}, state, {
+        error: true,
         history: state.history.concat({
             value: error.replace('$1', command),
         }),
@@ -19,9 +37,12 @@ export function reportError(state, error, command) {
 }
 
 /*
- * This is a utility method for chaining the relativePath
- * onto the rootPath. It includes backwards movement and
- * normalization.
+ * This is a utility method for appending a relative path
+ * to a root path. Handles trimming and backtracking.
+ *
+ * @param {string} relativePath
+ * @param {string} rootPath
+ * @returns {string} the combined path
  */
 export function extractPath(relativePath, rootPath) {
     // Short circuit for relative path
@@ -41,8 +62,12 @@ export function extractPath(relativePath, rootPath) {
 }
 
 /*
- * This is a utility method for traversing the <structure>
- * down the '/' separated <relativePath>
+ * This is a utility method for traversing the structure
+ * down the relative path.
+ *
+ * @param {Object} structure - the terminal file structure
+ * @param {string} relativePath - the path of the directory
+ * @returns {Object} the directory or error
  */
 export function getDirectoryByPath(structure, relativePath) {
     const path = relativePath.split('/');

--- a/tests/commands.js
+++ b/tests/commands.js
@@ -52,7 +52,7 @@ describe('bash commands', () => {
             const expected = Object.keys(state.structure)
                 .filter(name => name[0] !== '.')
                 .join(' ');
-            const { history } = bash.commands.ls.exec(state, {});
+            const { history } = bash.commands.ls.exec(state, { flags: {} });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -60,7 +60,8 @@ describe('bash commands', () => {
         it('should handle --all arg', () => {
             const state = stateFactory();
             const expected = Object.keys(state.structure).join(' ');
-            const { history } = bash.commands.ls.exec(state, { all: true });
+            const args = { flags: { a: true } };
+            const { history } = bash.commands.ls.exec(state, args);
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -68,14 +69,16 @@ describe('bash commands', () => {
         it('should handle --long arg', () => {
             const state = stateFactory();
             const expected = Object.keys(state.structure).length;
-            const { history } = bash.commands.ls.exec(state, { long: true, all: true });
+            const args = { flags: { a: true, l: true } };
+            const { history } = bash.commands.ls.exec(state, args);
             chai.assert.strictEqual(history.length, expected);
         });
 
         it('should handle a valid path arg', () => {
             const state = stateFactory();
             const expected = Object.keys(state.structure.dir1).join(' ');
-            const { history } = bash.commands.ls.exec(state, { 0: 'dir1' });
+            const args = { flags: {}, 0: 'dir1' };
+            const { history } = bash.commands.ls.exec(state, args);
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -83,7 +86,8 @@ describe('bash commands', () => {
         it('should handle a non existent path', () => {
             const state = stateFactory();
             const expected = Errors.NO_SUCH_FILE.replace('$1', 'doesNotExist');
-            const { history } = bash.commands.ls.exec(state, { 0: 'doesNotExist' });
+            const args = { flags: {}, 0: 'doesNotExist' };
+            const { history } = bash.commands.ls.exec(state, args);
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -91,7 +95,8 @@ describe('bash commands', () => {
         it('should handle path to file', () => {
             const state = stateFactory();
             const expected = Errors.NOT_A_DIRECTORY.replace('$1', 'file1');
-            const { history } = bash.commands.ls.exec(state, { 0: 'file1' });
+            const args = { flags: {}, 0: 'file1' };
+            const { history } = bash.commands.ls.exec(state, args);
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -1,0 +1,84 @@
+import chai from 'chai';
+import * as BashParser from '../src/parser';
+
+describe('BashParser', () => {
+
+    describe('parseInput', () => {
+        it('should exist', () => {
+            chai.assert.isFunction(BashParser.parseInput);
+        });
+
+        it('should handle a simple command', () => {
+            const { command } = BashParser.parseInput('ls');
+            chai.assert.strictEqual(command, 'ls');
+        });
+
+        it('should handle no args', () => {
+            const { command, args } = BashParser.parseInput('ls');
+            chai.assert.strictEqual(command, 'ls');
+            chai.assert.strictEqual(Object.keys(args).length, 1);
+            chai.assert.strictEqual(Object.keys(args.flags).length, 0);
+        });
+
+        it('should handle anonymous args', () => {
+            const { args } = BashParser.parseInput('ls arg1 arg2');
+            chai.assert.strictEqual(args[0], 'arg1');
+            chai.assert.strictEqual(args[1], 'arg2');
+        });
+
+        it('should handle named args', () => {
+            const { args } = BashParser.parseInput('ls --test arg1');
+            chai.assert.strictEqual(args.test, 'arg1');
+        });
+
+        it('should handle boolean flags', () => {
+            const { args } = BashParser.parseInput('ls -l -a');
+            chai.assert.strictEqual(Object.keys(args.flags).length, 2);
+            chai.assert.strictEqual(args.flags.l, true);
+            chai.assert.strictEqual(args.flags.a, true);
+        });
+
+        it('should handle grouped boolean flags', () => {
+            const { args } = BashParser.parseInput('ls -la');
+            chai.assert.strictEqual(Object.keys(args.flags).length, 2);
+            chai.assert.strictEqual(args.flags.l, true);
+            chai.assert.strictEqual(args.flags.a, true);
+        });
+
+    });
+
+    describe('parse', () => {
+
+        it('should exist', () => {
+            chai.assert.isFunction(BashParser.parse);
+        });
+
+        it('should handle a simple command', () => {
+            const parsedData = BashParser.parse('ls');
+            chai.assert.strictEqual(parsedData.length, 1);
+            chai.assert.strictEqual(parsedData[0].length, 1);
+            chai.assert.strictEqual(parsedData[0][0].command, 'ls');
+        });
+
+        it('should handle multiple commands with ;', () => {
+            const [parsedData] = BashParser.parse('ls -la; cd test');
+            const command1 = parsedData[0];
+            const command2 = parsedData[1];
+            chai.assert.strictEqual(command1.command, 'ls');
+            chai.assert.strictEqual(command1.args.flags.l, true);
+            chai.assert.strictEqual(command1.args.flags.a, true);
+            chai.assert.strictEqual(command2.command, 'cd');
+            chai.assert.strictEqual(command2.args[0], 'test');
+        });
+
+        it('should handle multiple commands with &&', () => {
+            const dependencyList = BashParser.parse('ls -a && cd test');
+            const [dep1, dep2] = dependencyList;
+            chai.assert.strictEqual(dependencyList.length, 2);
+            chai.assert.strictEqual(dep1[0].command, 'ls');
+            chai.assert.strictEqual(dep1[0].args.flags.a, true);
+            chai.assert.strictEqual(dep2[0].command, 'cd');
+            chai.assert.strictEqual(dep2[0].args[0], 'test');
+        });
+    });
+});

--- a/tests/util.js
+++ b/tests/util.js
@@ -7,24 +7,24 @@ const state = stateFactory();
 
 describe('util method', () => {
 
-    describe('reportError', () => {
+    describe('appendError', () => {
 
         it('should exist', () => {
-            chai.assert.isFunction(Util.reportError);
+            chai.assert.isFunction(Util.appendError);
         });
 
         it('should immutably alter state', () => {
-            const newState = Util.reportError(state, '-$1-', 'test');
+            const newState = Util.appendError(state, '-$1-', 'test');
             chai.assert.notStrictEqual(state, newState);
         });
 
         it('should add error to history', () => {
-            const newState = Util.reportError(state, '-$1-', 'test');
+            const newState = Util.appendError(state, '-$1-', 'test');
             chai.assert.strictEqual(newState.history.length, state.history.length + 1);
         });
 
         it('should interpolate the command into error', () => {
-            const newState = Util.reportError(state, '-$1-', 'test');
+            const newState = Util.appendError(state, '-$1-', 'test');
             chai.assert.strictEqual(newState.history[0].value, '-test-');
         });
 


### PR DESCRIPTION
#### Arg parsing improvements:

- automatically handle grouped flags (`-lah`)
- handles multi-command inputs (`cd test; cat foo.txt`)
- handles multi-command inputs with dependency (`cd test && cat foo.txt`)
- now uses the bash approach instead of the [yarg](https://www.npmjs.com/package/yargs) approach.
    - Single dash is for flag groups
    - Double dash is for named commands
- Added more tests
- Added more doc strings