### PR TITLE
Flatten command arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The `extension` prop is an easy way to extend the bash commands that can be pars
 import Terminal from 'react-bash';
 
 export const clear = {
-    exec: ({ structure, history, cwd }, args) => {
+    exec: ({ structure, history, cwd }, command) => {
         return { structure, cwd, history: [] };
     },
 };
@@ -35,15 +35,18 @@ const extensions = { clear };
 <Terminal extensions={extensions} />
 ```
 
-Each command is given the `state` and a parsed `args` object. Some commands can use optional or required arguments. There are three types of arguments: `anonymous` args, `named` args (--), and `flag` args (-). To see how ReactBash parses the input, check out this fictional example that utilizes all three in order.
+Each command is given the `state` and a parsed `command` object. The command object provides the `name`, `input`, `args`, and `flags` corresponding to the input. Some commands can use optional or required arguments. There are three types of args: `anonymous` args, `named` args (--), and `flag` args (-). To see how ReactBash parses the input.
 
 For the input `foo some/path -baz --hello world`, ReactBash would parse the input as:
 ```js
-command = 'foo'
-args = {
+{
+  command = 'foo'
+  input: 'foo some/path -baz --hello world',
+  args: {
     0: 'some/path',
     hello: 'world',
-    flags: { b: true, a: true, z: true },
+  },
+  flags: { b: true, a: true, z: true },
 }
 ```
 

--- a/src/bash.js
+++ b/src/bash.js
@@ -53,16 +53,16 @@ export default class Bash {
          * occurred. If an error occurs, the following dependent commands should
          * not be run.
          */
-        const reducer = (newState, { command, args }) => {
-            if (command === '') {
+        const reducer = (newState, command) => {
+            if (command.name === '') {
                 return newState;
-            } else if (this.commands[command]) {
-                const nextState = this.commands[command].exec(newState, args);
+            } else if (this.commands[command.name]) {
+                const nextState = this.commands[command.name].exec(newState, command);
                 errorOccurred = errorOccurred || (nextState && nextState.error);
                 return nextState;
             } else {
                 errorOccurred = true;
-                return Util.appendError(newState, Errors.COMMAND_NOT_FOUND, command);
+                return Util.appendError(newState, Errors.COMMAND_NOT_FOUND, command.name);
             }
         };
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -22,7 +22,7 @@ export const clear = {
 };
 
 export const ls = {
-    exec: (state, args) => {
+    exec: (state, { flags, args }) => {
         const path = args[0] || '';
         const fullPath = Util.extractPath(path, state.cwd);
         const { err, dir } = Util.getDirectoryByPath(state.structure, fullPath);
@@ -31,10 +31,10 @@ export const ls = {
             return Util.appendError(state, err, path);
         } else {
             let content = Object.keys(dir);
-            if (!args.$flags.a) {
+            if (!flags.a) {
                 content = content.filter(name => name[0] !== '.');
             }
-            if (args.$flags.l) {
+            if (flags.l) {
                 return Object.assign({}, state, {
                     history: state.history.concat(content.map(value => {
                         return { value };
@@ -50,7 +50,7 @@ export const ls = {
 };
 
 export const cat = {
-    exec: (state, args) => {
+    exec: (state, { args }) => {
         const path = args[0];
         const relativePath = path.split('/');
         const fileName = relativePath.pop();
@@ -73,7 +73,7 @@ export const cat = {
 };
 
 export const mkdir = {
-    exec: (state, args) => {
+    exec: (state, { args }) => {
         const path = args[0];
         const relativePath = path.split('/');
         const newDirectory = relativePath.pop();
@@ -91,7 +91,7 @@ export const mkdir = {
 };
 
 export const cd = {
-    exec: (state, args) => {
+    exec: (state, { args }) => {
         const path = args[0];
         if (!path || path === '/') {
             return Object.assign({}, state, { cwd: '' });
@@ -118,10 +118,10 @@ export const pwd = {
 };
 
 export const echo = {
-    exec: (state, { $input }) => {
+    exec: (state, { input }) => {
         const ECHO_LENGTH = 'echo '.length;
         const envVariables = Util.getEnvVariables(state);
-        const value = $input.slice(ECHO_LENGTH).replace(/(\$\w+)/g, key => {
+        const value = input.slice(ECHO_LENGTH).replace(/(\$\w+)/g, key => {
             return envVariables[key.slice(1)] || '';
         });
         return Object.assign({}, state, {

--- a/src/parser.js
+++ b/src/parser.js
@@ -8,8 +8,9 @@
  */
 export function parseInput(input) {
     const tokens = input.split(/ +/);
-    const command = tokens.shift();
-    const args = { $flags: {}, $input: input };
+    const name = tokens.shift();
+    const flags = {};
+    const args = {};
     let anonArgPos = 0;
 
     while (tokens.length > 0) {
@@ -19,16 +20,15 @@ export function parseInput(input) {
                 const next = tokens.shift();
                 args[token.slice(2)] = next;
             } else {
-                const flags = token.slice(1).split('');
-                flags.forEach(flag => {
-                    args.$flags[flag] = true;
+                token.slice(1).split('').forEach(flag => {
+                    flags[flag] = true;
                 });
             }
         } else {
             args[anonArgPos++] = token;
         }
     }
-    return { command, args };
+    return { name, flags, input, args };
 }
 
 /*

--- a/tests/commands.js
+++ b/tests/commands.js
@@ -52,7 +52,7 @@ describe('bash commands', () => {
             const expected = Object.keys(state.structure)
                 .filter(name => name[0] !== '.')
                 .join(' ');
-            const { history } = bash.commands.ls.exec(state, { $flags: {} });
+            const { history } = bash.commands.ls.exec(state, { flags: {}, args: {} });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -60,8 +60,8 @@ describe('bash commands', () => {
         it('should handle --all arg', () => {
             const state = stateFactory();
             const expected = Object.keys(state.structure).join(' ');
-            const args = { $flags: { a: true } };
-            const { history } = bash.commands.ls.exec(state, args);
+            const command = { flags: { a: true }, args: {} };
+            const { history } = bash.commands.ls.exec(state, command);
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -69,16 +69,16 @@ describe('bash commands', () => {
         it('should handle --long arg', () => {
             const state = stateFactory();
             const expected = Object.keys(state.structure).length;
-            const args = { $flags: { a: true, l: true } };
-            const { history } = bash.commands.ls.exec(state, args);
+            const command = { flags: { a: true, l: true }, args: {} };
+            const { history } = bash.commands.ls.exec(state, command);
             chai.assert.strictEqual(history.length, expected);
         });
 
         it('should handle a valid path arg', () => {
             const state = stateFactory();
             const expected = Object.keys(state.structure.dir1).join(' ');
-            const args = { $flags: {}, 0: 'dir1' };
-            const { history } = bash.commands.ls.exec(state, args);
+            const command = { flags: {}, args: { 0: 'dir1' } };
+            const { history } = bash.commands.ls.exec(state, command);
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -86,8 +86,8 @@ describe('bash commands', () => {
         it('should handle a non existent path', () => {
             const state = stateFactory();
             const expected = Errors.NO_SUCH_FILE.replace('$1', 'doesNotExist');
-            const args = { $flags: {}, 0: 'doesNotExist' };
-            const { history } = bash.commands.ls.exec(state, args);
+            const command = { flags: {}, args: { 0: 'doesNotExist' } };
+            const { history } = bash.commands.ls.exec(state, command);
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -95,8 +95,8 @@ describe('bash commands', () => {
         it('should handle path to file', () => {
             const state = stateFactory();
             const expected = Errors.NOT_A_DIRECTORY.replace('$1', 'file1');
-            const args = { $flags: {}, 0: 'file1' };
-            const { history } = bash.commands.ls.exec(state, args);
+            const command = { flags: {}, args: { 0: 'file1' } };
+            const { history } = bash.commands.ls.exec(state, command);
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -112,7 +112,7 @@ describe('bash commands', () => {
         it('should display file contents', () => {
             const state = stateFactory();
             const expected = state.structure.file1.content;
-            const { history } = bash.commands.cat.exec(state, { 0: 'file1' });
+            const { history } = bash.commands.cat.exec(state, { args: { 0: 'file1' } });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -120,7 +120,7 @@ describe('bash commands', () => {
         it('should display file contents from path', () => {
             const state = stateFactory();
             const expected = state.structure.dir1.dir1File.content;
-            const { history } = bash.commands.cat.exec(state, { 0: 'dir1/dir1File' });
+            const { history } = bash.commands.cat.exec(state, { args: { 0: 'dir1/dir1File' } });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -128,7 +128,7 @@ describe('bash commands', () => {
         it('should not work for directories', () => {
             const state = stateFactory();
             const expected = Errors.IS_A_DIRECTORY.replace('$1', 'dir1');
-            const { history } = bash.commands.cat.exec(state, { 0: 'dir1' });
+            const { history } = bash.commands.cat.exec(state, { args: { 0: 'dir1' } });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -136,7 +136,7 @@ describe('bash commands', () => {
         it('should not work for invalid paths', () => {
             const state = stateFactory();
             const expected = Errors.NO_SUCH_FILE.replace('$1', 'doesNotExist');
-            const { history } = bash.commands.cat.exec(state, { 0: 'doesNotExist' });
+            const { history } = bash.commands.cat.exec(state, { args: { 0: 'doesNotExist' } });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -144,7 +144,7 @@ describe('bash commands', () => {
         it('should not work for nested invalid paths', () => {
             const state = stateFactory();
             const expected = Errors.NO_SUCH_FILE.replace('$1', 'dir1/doesNotExist');
-            const { history } = bash.commands.cat.exec(state, { 0: 'dir1/doesNotExist' });
+            const { history } = bash.commands.cat.exec(state, { args: { 0: 'dir1/doesNotExist' } });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -152,7 +152,7 @@ describe('bash commands', () => {
         it('should not work for directory paths', () => {
             const state = stateFactory();
             const expected = Errors.IS_A_DIRECTORY.replace('$1', 'dir1/childDir');
-            const { history } = bash.commands.cat.exec(state, { 0: 'dir1/childDir' });
+            const { history } = bash.commands.cat.exec(state, { args: { 0: 'dir1/childDir' } });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -168,14 +168,14 @@ describe('bash commands', () => {
         it('should create a new directory', () => {
             const state = stateFactory();
             chai.assert.isUndefined(state.structure.testDir);
-            const { structure } = bash.commands.mkdir.exec(state, { 0: 'testDir' });
+            const { structure } = bash.commands.mkdir.exec(state, { args: { 0: 'testDir' } });
             chai.assert.isDefined(structure.testDir);
         });
 
         it('should create a new directory at path', () => {
             const state = stateFactory();
             chai.assert.isUndefined(state.structure.dir1.testDir);
-            const { structure } = bash.commands.mkdir.exec(state, { 0: 'dir1/testDir' });
+            const { structure } = bash.commands.mkdir.exec(state, { args: { 0: 'dir1/testDir' } });
             chai.assert.isDefined(structure.dir1.testDir);
         });
 
@@ -183,7 +183,7 @@ describe('bash commands', () => {
             const state = stateFactory();
             const expected = Errors.FILE_EXISTS.replace('$1', 'dir1');
             chai.assert.isDefined(state.structure.dir1);
-            const { history } = bash.commands.mkdir.exec(state, { 0: 'dir1' });
+            const { history } = bash.commands.mkdir.exec(state, { args: { 0: 'dir1' } });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -192,7 +192,7 @@ describe('bash commands', () => {
             const state = stateFactory();
             const expected = Errors.FILE_EXISTS.replace('$1', 'dir1/childDir');
             chai.assert.isDefined(state.structure.dir1);
-            const { history } = bash.commands.mkdir.exec(state, { 0: 'dir1/childDir' });
+            const { history } = bash.commands.mkdir.exec(state, { args: { 0: 'dir1/childDir' } });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, expected);
         });
@@ -208,34 +208,34 @@ describe('bash commands', () => {
         it('should work with no args', () => {
             const state = stateFactory();
             state.cwd = 'dir1';
-            const { cwd } = bash.commands.cd.exec(state, {});
+            const { cwd } = bash.commands.cd.exec(state, { args: {} });
             chai.assert.strictEqual(cwd, '');
         });
 
         it('should work with path', () => {
             const state = stateFactory();
-            const { cwd } = bash.commands.cd.exec(state, { 0: 'dir1/childDir' });
+            const { cwd } = bash.commands.cd.exec(state, { args: { 0: 'dir1/childDir' } });
             chai.assert.strictEqual(cwd, 'dir1/childDir');
         });
 
         it('should work with ..', () => {
             const state = stateFactory();
             state.cwd = 'dir1/childDir';
-            const { cwd } = bash.commands.cd.exec(state, { 0: '..' });
+            const { cwd } = bash.commands.cd.exec(state, { args: { 0: '..' } });
             chai.assert.strictEqual(cwd, 'dir1');
         });
 
         it('should work with multiple ..', () => {
             const state = stateFactory();
             state.cwd = 'dir1/childDir';
-            const { cwd } = bash.commands.cd.exec(state, { 0: '../../' });
+            const { cwd } = bash.commands.cd.exec(state, { args: { 0: '../../' } });
             chai.assert.strictEqual(cwd, '');
         });
 
         it('should work with back and forth', () => {
             const state = stateFactory();
             state.cwd = 'dir1/childDir';
-            const { cwd } = bash.commands.cd.exec(state, { 0: '../childDir' });
+            const { cwd } = bash.commands.cd.exec(state, { args: { 0: '../childDir' } });
             chai.assert.strictEqual(cwd, 'dir1/childDir');
         });
 
@@ -271,25 +271,25 @@ describe('bash commands', () => {
         });
 
         it('should print out empty arguments', () => {
-            const { history } = bash.commands.echo.exec(state, { $input: 'echo' });
+            const { history } = bash.commands.echo.exec(state, { input: 'echo' });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, '');
         });
 
         it('should print out arguments', () => {
-            const { history } = bash.commands.echo.exec(state, { $input: 'echo foo bar' });
+            const { history } = bash.commands.echo.exec(state, { input: 'echo foo bar' });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, 'foo bar');
         });
 
         it('should print out static environment variables', () => {
-            const { history } = bash.commands.echo.exec(state, { $input: 'echo $HOME' });
+            const { history } = bash.commands.echo.exec(state, { input: 'echo $HOME' });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, '/');
         });
 
         it('should print out dynamic environment variables', () => {
-            const { history } = bash.commands.echo.exec(state, { $input: 'echo $PWD' });
+            const { history } = bash.commands.echo.exec(state, { input: 'echo $PWD' });
             chai.assert.strictEqual(history.length, 1);
             chai.assert.strictEqual(history[0].value, `/${state.cwd}`);
         });

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -9,16 +9,15 @@ describe('BashParser', () => {
         });
 
         it('should handle a simple command', () => {
-            const { command, args } = BashParser.parseInput('ls');
-            chai.assert.strictEqual(command, 'ls');
-            chai.assert.strictEqual(args.$input, 'ls');
+            const { name, input } = BashParser.parseInput('ls');
+            chai.assert.strictEqual(name, 'ls');
+            chai.assert.strictEqual(input, 'ls');
         });
 
         it('should handle no args', () => {
-            const { command, args } = BashParser.parseInput('ls');
-            chai.assert.strictEqual(command, 'ls');
-            chai.assert.strictEqual(Object.keys(args).length, 2);
-            chai.assert.strictEqual(Object.keys(args.$flags).length, 0);
+            const { name, flags } = BashParser.parseInput('ls');
+            chai.assert.strictEqual(name, 'ls');
+            chai.assert.strictEqual(Object.keys(flags).length, 0);
         });
 
         it('should handle anonymous args', () => {
@@ -32,18 +31,18 @@ describe('BashParser', () => {
             chai.assert.strictEqual(args.test, 'arg1');
         });
 
-        it('should handle boolean $flags', () => {
-            const { args } = BashParser.parseInput('ls -l -a');
-            chai.assert.strictEqual(Object.keys(args.$flags).length, 2);
-            chai.assert.strictEqual(args.$flags.l, true);
-            chai.assert.strictEqual(args.$flags.a, true);
+        it('should handle boolean flags', () => {
+            const { flags } = BashParser.parseInput('ls -l -a');
+            chai.assert.strictEqual(Object.keys(flags).length, 2);
+            chai.assert.strictEqual(flags.l, true);
+            chai.assert.strictEqual(flags.a, true);
         });
 
-        it('should handle grouped boolean $flags', () => {
-            const { args } = BashParser.parseInput('ls -la');
-            chai.assert.strictEqual(Object.keys(args.$flags).length, 2);
-            chai.assert.strictEqual(args.$flags.l, true);
-            chai.assert.strictEqual(args.$flags.a, true);
+        it('should handle grouped boolean flags', () => {
+            const { flags } = BashParser.parseInput('ls -la');
+            chai.assert.strictEqual(Object.keys(flags).length, 2);
+            chai.assert.strictEqual(flags.l, true);
+            chai.assert.strictEqual(flags.a, true);
         });
 
     });
@@ -58,17 +57,17 @@ describe('BashParser', () => {
             const parsedData = BashParser.parse('ls');
             chai.assert.strictEqual(parsedData.length, 1);
             chai.assert.strictEqual(parsedData[0].length, 1);
-            chai.assert.strictEqual(parsedData[0][0].command, 'ls');
+            chai.assert.strictEqual(parsedData[0][0].name, 'ls');
         });
 
         it('should handle multiple commands with ;', () => {
             const [parsedData] = BashParser.parse('ls -la; cd test');
             const command1 = parsedData[0];
             const command2 = parsedData[1];
-            chai.assert.strictEqual(command1.command, 'ls');
-            chai.assert.strictEqual(command1.args.$flags.l, true);
-            chai.assert.strictEqual(command1.args.$flags.a, true);
-            chai.assert.strictEqual(command2.command, 'cd');
+            chai.assert.strictEqual(command1.name, 'ls');
+            chai.assert.strictEqual(command1.flags.l, true);
+            chai.assert.strictEqual(command1.flags.a, true);
+            chai.assert.strictEqual(command2.name, 'cd');
             chai.assert.strictEqual(command2.args[0], 'test');
         });
 
@@ -76,9 +75,9 @@ describe('BashParser', () => {
             const dependencyList = BashParser.parse('ls -a && cd test');
             const [dep1, dep2] = dependencyList;
             chai.assert.strictEqual(dependencyList.length, 2);
-            chai.assert.strictEqual(dep1[0].command, 'ls');
-            chai.assert.strictEqual(dep1[0].args.$flags.a, true);
-            chai.assert.strictEqual(dep2[0].command, 'cd');
+            chai.assert.strictEqual(dep1[0].name, 'ls');
+            chai.assert.strictEqual(dep1[0].flags.a, true);
+            chai.assert.strictEqual(dep2[0].name, 'cd');
             chai.assert.strictEqual(dep2[0].args[0], 'test');
         });
     });


### PR DESCRIPTION
This PR normalizes the second argument of commands. It went from
```
{
    command: 'ls',
    args: {
        $flags: { a: true },
        $input: 'ls -a --foo bar test',
       foo: 'bar',
       0: 'test',
    }
}
```
to this:
```
{
    name: 'ls',
    args: { foo: 'bar', 0: 'test' },
    flags: { a: true },
    input: 'ls -a --foo ba',
}
```