### PR TITLE
Adds support for long running commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,33 @@ Similarly to synchronous extensions, the promise should resolve to the new state
 If it fails, the rejected error (if available) will be printed in the terminal:
 
 ```js
-export const clear = {
-    exec: ({ structure, history, cwd }, command) => {
-        return Promise.resolve({ structure, cwd, history: [] });
+export const sleep = {
+    exec: (state, { args }) => {
+        let duration = parseFloat(args[0]);
+        if (isNaN(duration)) {
+            duration = 0;
+        }
+        return new Promise((resolve) => setTimeout(() => resolve(state), duration * 1000));
+    },
+};
+```
+
+Extensions may also return [generators](https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Iterators_and_Generators),
+to handle commands that outputs several steps.
+Note that generators may also yield promises.
+
+```js
+export const langc = {
+    exec: (state, { args }) => {
+        return (function* () {
+            let nextState = Object.assign({}, state);
+            for (const value of ['building ...', 'linking ...']) {
+                nextState = Object.assign({}, nextState, {
+                    history: nextState.history.concat({ value })
+                });
+                yield nextState;
+            }
+        }());
     },
 };
 ```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ For the input `foo some/path -baz --hello world`, ReactBash would parse the inpu
 }
 ```
 
+Extensions are also allowed to return a promise, to handle long running commands.
+Similarly to synchronous extensions, the promise should resolve to the new state of the terminal.
+If it fails, the rejected error (if available) will be printed in the terminal:
+
+```js
+export const clear = {
+    exec: ({ structure, history, cwd }, command) => {
+        return Promise.resolve({ structure, cwd, history: [] });
+    },
+};
+```
+
 ### History
 The history prop and state arrays are lists of items that will be displayed as history items in the terminal. Essentially, anything that gets 'printed' out onto the terminal is a `history` item. The `prefix` prop is available to alter the bash user info that prepends commands in the history. If you'd like to add a welcome message to the initial state of the terminal, it's as easy as passing in a prop.
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-jsx-a11y": "^1.2.3",
     "eslint-plugin-react": "^5.1.1",
     "mocha": "^2.2.5",
-    "react": "^0.14.8",
+    "react": "^15.4.2",
     "react-addons-test-utils": "^15.1.0",
     "react-dom": "^15.3.0",
     "rimraf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "rimraf lib dist es",
     "lint": "eslint src tests",
     "start": "cd demo && node server.js",
-    "test": "cross-env BABEL_ENV=commonjs mocha --compilers js:babel-core/register --reporter spec tests/*.js",
+    "test": "cross-env BABEL_ENV=commonjs mocha --compilers js:babel-core/register --require babel-polyfill --reporter spec tests/*.js",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",
     "build:umd": "cross-env BABEL_ENV=commonjs NODE_ENV=development webpack src/index.js dist/react-bash.js",

--- a/src/bash.js
+++ b/src/bash.js
@@ -12,6 +12,26 @@ export default class Bash {
     }
 
     /*
+     * This adds the given <input> into the terminal history
+     *
+     * @param {string} input - the user input
+     * @param {Object} state - the current terminal state
+     * @returns {Object} the new terminal state
+     */
+    pushInput(input, currentState) {
+        this.prevCommands.push(input);
+        this.prevCommandsIndex = this.prevCommands.length;
+
+        // Append input to history
+        return Object.assign({}, currentState, {
+            history: currentState.history.concat({
+                cwd: currentState.cwd,
+                value: input,
+            }),
+        });
+    }
+
+    /*
      * This parses and executes the given <input> and returns an updated
      * state object.
      *
@@ -20,19 +40,8 @@ export default class Bash {
      * @returns {Object} a promise that resolves to the new terminal state
      */
     execute(input, currentState) {
-        this.prevCommands.push(input);
-        this.prevCommandsIndex = this.prevCommands.length;
-
-        // Append input to history
-        const newState = Object.assign({}, currentState, {
-            history: currentState.history.concat({
-                cwd: currentState.cwd,
-                value: input,
-            }),
-        });
-
         const commandList = BashParser.parse(input);
-        return this.runCommands(commandList, newState);
+        return this.runCommands(commandList, currentState);
     }
 
     /*

--- a/src/bash.js
+++ b/src/bash.js
@@ -37,6 +37,7 @@ export default class Bash {
      *
      * @param {string} input - the user input
      * @param {Object} state - the current terminal state
+     * @param {function} state - a state progress observer callback
      * @returns {Object} a promise that resolves to the new terminal state
      */
     execute(input, currentState, progressObserver = () => {}) {
@@ -52,6 +53,7 @@ export default class Bash {
      *
      * @param {Array} commands - the commands to run
      * @param {Object} state - the terminal state
+     * @param {function} state - a state progress observer callback
      * @returns {Object} a promise that resolves to the new terminal state
      */
     runCommands(commands, state, progressObserver = () => {}) {

--- a/src/bash.js
+++ b/src/bash.js
@@ -73,18 +73,18 @@ export default class Bash {
                         errorOccurred = errorOccurred || (newState && newState.error);
                         return errorOccurred
                             ? newState
-                            : Promise.resolve(this.commands[command.name].exec(newState, command));
+                            : Promise.resolve(this.commands[command.name].exec(newState, command))
+                                .catch((error) => {
+                                    errorOccurred = true;
+                                    const message = (error && error.message)
+                                        ? error.message
+                                        : `command ${command.name} failed`;
+                                    return Util.appendError(newState, '$1', message);
+                                });
                     } else {
                         errorOccurred = true;
                         return Util.appendError(newState, Errors.COMMAND_NOT_FOUND, command.name);
                     }
-                })
-                .catch((error) => {
-                    errorOccurred = true;
-                    const message = (error && error.message)
-                        ? error.message
-                        : `command ${command.name} failed`;
-                    return Util.appendError(newState, '$1', `command ${command.name} failed`);
                 });
         };
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -174,7 +174,7 @@ export const rm = {
 };
 
 export const sleep = {
-    exec: (state, { flags, args }) => {
+    exec: (state, { args }) => {
         let duration = parseFloat(args[0]);
         if (isNaN(duration)) {
             duration = 0;

--- a/src/commands.js
+++ b/src/commands.js
@@ -1,7 +1,7 @@
 import * as Util from './util';
 import { Errors } from './const';
 
-const helpCommands = ['clear', 'ls', 'cat', 'mkdir', 'cd', 'pwd', 'echo', 'printenv', 'whoami', 'rm'];
+const helpCommands = ['clear', 'ls', 'cat', 'mkdir', 'cd', 'pwd', 'echo', 'printenv', 'whoami', 'rm', 'sleep'];
 
 export const help = {
     exec: (state) => {
@@ -170,5 +170,15 @@ export const rm = {
         } else {
             return Util.appendError(state, Errors.NO_SUCH_FILE, path);
         }
+    },
+};
+
+export const sleep = {
+    exec: (state, { flags, args }) => {
+        let duration = parseFloat(args[0]);
+        if (isNaN(duration)) {
+            duration = 0;
+        }
+        return new Promise((resolve) => setTimeout(() => resolve(state), duration * 1000));
     },
 };

--- a/src/component.js
+++ b/src/component.js
@@ -23,7 +23,7 @@ export default class Terminal extends Component {
             structure: Object.assign({}, structure),
             cwd: '',
             isBusy: false,
-            _bashExecutionsObserver: null,
+            bashExecutionsObserver: null,
         };
         this.handleKeyDown = this.handleKeyDown.bind(this);
         this.handleKeyUp = this.handleKeyUp.bind(this);
@@ -102,12 +102,12 @@ export default class Terminal extends Component {
     handleKeyUp(evt) {
         if (evt.which === L_CHAR_CODE) {
             if (this.ctrlPressed) {
-                let observer = this.Bash.execute('clear', this.state)
+                const observer = this.Bash.execute('clear', this.state)
                     .then((newState) => { this.setState(newState); });
 
                 // Test instrumentation
-                if (this.props._observeBashExecutions) {
-                    this.setState({ _bashExecutionsObserver: observer });
+                if (this.props.observeBashExecutions) {
+                    this.setState({ bashExecutionsObserver: observer });
                 }
             }
         } else if (evt.which === C_CHAR_CODE) {
@@ -135,17 +135,17 @@ export default class Terminal extends Component {
         const input = evt.target[0].value;
 
         this.setState(
-            Object.assign({}, this.Bash.pushInput(input, this.state), {isBusy: true}),
+            Object.assign({}, this.Bash.pushInput(input, this.state), { isBusy: true }),
             () => {
                 // Execute command
-                let observer = this.Bash.execute(input, this.state).then((newState) => {
-                    this.setState(Object.assign({}, newState, {isBusy: false}));
+                const observer = this.Bash.execute(input, this.state).then((newState) => {
+                    this.setState(Object.assign({}, newState, { isBusy: false }));
                 });
                 this.refs.input.value = '';
 
                 // Test instrumentation
-                if (this.props._observeBashExecutions) {
-                    this.setState({ _bashExecutionsObserver: observer });
+                if (this.props.observeBashExecutions) {
+                    this.setState({ bashExecutionsObserver: observer });
                 }
             });
     }
@@ -212,7 +212,7 @@ Terminal.propTypes = {
 
     // This property serves to enable the instrumentation of the component, so
     // that asynchronous updates of its state can be observed during testing.
-    _observeBashExecutions: PropTypes.bool,
+    observeBashExecutions: PropTypes.bool,
 };
 
 Terminal.defaultProps = {
@@ -224,5 +224,5 @@ Terminal.defaultProps = {
     prefix: 'hacker@default',
     structure: {},
     theme: Terminal.Themes.LIGHT,
-    _observeBashExecutions: false,
+    observeBashExecutions: false,
 };

--- a/src/component.js
+++ b/src/component.js
@@ -100,7 +100,8 @@ export default class Terminal extends Component {
     handleKeyUp(evt) {
         if (evt.which === L_CHAR_CODE) {
             if (this.ctrlPressed) {
-                this.setState(this.Bash.execute('clear', this.state));
+                this.Bash.execute('clear', this.state)
+                    .then((newState) => { this.setState(newState); });
             }
         } else if (evt.which === C_CHAR_CODE) {
             if (this.ctrlPressed) {
@@ -126,8 +127,8 @@ export default class Terminal extends Component {
 
         // Execute command
         const input = evt.target[0].value;
-        const newState = this.Bash.execute(input, this.state);
-        this.setState(newState);
+        this.Bash.execute(input, this.state)
+            .then((newState) => { this.setState(newState); });
         this.refs.input.value = '';
     }
 

--- a/src/component.js
+++ b/src/component.js
@@ -22,6 +22,7 @@ export default class Terminal extends Component {
             history: history.slice(),
             structure: Object.assign({}, structure),
             cwd: '',
+            _bashExecutionsObserver: null,
         };
         this.handleKeyDown = this.handleKeyDown.bind(this);
         this.handleKeyUp = this.handleKeyUp.bind(this);
@@ -100,8 +101,11 @@ export default class Terminal extends Component {
     handleKeyUp(evt) {
         if (evt.which === L_CHAR_CODE) {
             if (this.ctrlPressed) {
-                this.Bash.execute('clear', this.state)
+                let observer = this.Bash.execute('clear', this.state)
                     .then((newState) => { this.setState(newState); });
+                if (this.props._observeBashExecutions) {
+                    this.setState({ _bashExecutionsObserver: observer });
+                }
             }
         } else if (evt.which === C_CHAR_CODE) {
             if (this.ctrlPressed) {
@@ -127,8 +131,11 @@ export default class Terminal extends Component {
 
         // Execute command
         const input = evt.target[0].value;
-        this.Bash.execute(input, this.state)
+        let observer = this.Bash.execute(input, this.state)
             .then((newState) => { this.setState(newState); });
+        if (this.props._observeBashExecutions) {
+            this.setState({ _bashExecutionsObserver: observer });
+        }
         this.refs.input.value = '';
     }
 
@@ -184,6 +191,10 @@ Terminal.propTypes = {
     prefix: PropTypes.string,
     structure: PropTypes.object,
     theme: PropTypes.string,
+
+    // This property serves to enable the instrumentation of the component, so
+    // that asynchronous updates of its state can be observed during testing.
+    _observeBashExecutions: PropTypes.bool,
 };
 
 Terminal.defaultProps = {
@@ -195,4 +206,5 @@ Terminal.defaultProps = {
     prefix: 'hacker@default',
     structure: {},
     theme: Terminal.Themes.LIGHT,
+    _observeBashExecutions: false,
 };

--- a/tests/bash.js
+++ b/tests/bash.js
@@ -35,44 +35,42 @@ describe('bash class methods', () => {
         bash = new Bash();
     });
 
+    describe('pushInput', () => {
+
+        it('should exist', () => {
+            chai.assert.isFunction(bash.pushInput);
+        });
+
+        it('should append command to prevCommands', () => {
+            bash.pushInput('test', mockState);
+            chai.assert.strictEqual(bash.prevCommands.length, 1);
+            chai.assert.strictEqual(bash.prevCommands[0], 'test');
+        });
+
+        it('should increase prevCommandsIndex', () => {
+            bash.pushInput('test', mockState);
+            chai.assert.strictEqual(bash.prevCommandsIndex, 1);
+        });
+
+        it('should add input to history', () => {
+            const { history } = bash.pushInput('ls', mockState);
+            chai.assert.strictEqual(history.length, 1);
+            chai.assert.strictEqual(history[0].value, 'ls');
+            chai.assert.strictEqual(history[0].cwd, '');
+        });
+
+        it('should add a blank line on empty input', () => {
+            const { history } = bash.pushInput('', mockState);
+            chai.assert.strictEqual(history.length, 1);
+            chai.assert.strictEqual(history[0].value, '');
+        });
+
+    });
+
     describe('execute', () => {
 
         it('should exist', () => {
             chai.assert.isFunction(bash.execute);
-        });
-
-        it('should append command to prevCommands', () => {
-            let testCase = bash.execute('test', mockState);
-            return testCase.then(() => {
-                chai.assert.strictEqual(bash.prevCommands.length, 1);
-                chai.assert.strictEqual(bash.prevCommands[0], 'test');
-            });
-        });
-
-        it('should increase prevCommandsIndex', () => {
-            let testCase = bash.execute('test', mockState);
-            return testCase.then(() => {
-                chai.assert.strictEqual(bash.prevCommandsIndex, 1);
-            });
-        });
-
-        it('should add input to history', () => {
-            let testCase = bash.execute('ls', mockState);
-            return testCase.then((newState) => {
-                const { history } = newState;
-                chai.assert.strictEqual(history.length, 2);
-                chai.assert.strictEqual(history[0].value, 'ls');
-                chai.assert.strictEqual(history[0].cwd, '');
-            });
-        });
-
-        it('should not break on empty input', () => {
-            let testCase = bash.execute('', mockState);
-            return testCase.then((newState) => {
-                const { history } = newState;
-                chai.assert.strictEqual(history.length, 1);
-                chai.assert.strictEqual(history[0].value, '');
-            });
         });
 
         // Full command testing is in tests/command.js
@@ -106,8 +104,8 @@ describe('bash class methods', () => {
             const testCase = bash.execute('commandDoesNotExist', mockState);
             return testCase.then((newState) => {
                 const { history } = newState;
-                chai.assert.strictEqual(history.length, 2);
-                chai.assert.strictEqual(history[1].value, expected);
+                chai.assert.strictEqual(history.length, 1);
+                chai.assert.strictEqual(history[0].value, expected);
             });
         });
 
@@ -116,7 +114,7 @@ describe('bash class methods', () => {
             const testCase = bash.execute('commandDoesNotExist -la test/file.txt', mockState);
             return testCase.then((newState) => {
                 const { history } = newState;
-                chai.assert.strictEqual(history[1].value, expected);
+                chai.assert.strictEqual(history[0].value, expected);
             });
         });
 
@@ -124,8 +122,8 @@ describe('bash class methods', () => {
             const testCase = bash.execute('cd dir1; pwd', mockState);
             return testCase.then((newState) => {
                 const { history } = newState;
-                chai.assert.strictEqual(history.length, 2);
-                chai.assert.strictEqual(history[1].value, '/dir1');
+                chai.assert.strictEqual(history.length, 1);
+                chai.assert.strictEqual(history[0].value, '/dir1');
             });
         });
 
@@ -133,8 +131,8 @@ describe('bash class methods', () => {
             const testCase = bash.execute('cd dir1; pwd', mockState);
             return testCase.then((newState) => {
                 const { history } = newState;
-                chai.assert.strictEqual(history.length, 2);
-                chai.assert.strictEqual(history[1].value, '/dir1');
+                chai.assert.strictEqual(history.length, 1);
+                chai.assert.strictEqual(history[0].value, '/dir1');
             });
         });
 
@@ -144,9 +142,8 @@ describe('bash class methods', () => {
             const testCase = bash.execute(input, mockState);
             return testCase.then((newState) => {
                 const { history } = newState;
-                chai.assert.strictEqual(history.length, 2);
-                chai.assert.strictEqual(history[0].value, input);
-                chai.assert.strictEqual(history[1].value, expected1);
+                chai.assert.strictEqual(history.length, 1);
+                chai.assert.strictEqual(history[0].value, expected1);
             });
         });
 

--- a/tests/bash.js
+++ b/tests/bash.js
@@ -73,6 +73,30 @@ describe('bash class methods', () => {
             chai.assert.isFunction(bash.execute);
         });
 
+        it('should handle fulfilled promises', () => {
+            const bash = new Bash({
+                test: { exec: (state) => Promise.resolve('foo') }
+            });
+
+            const testCase = bash.execute('test', {});
+            return testCase.then((newState) => {
+                chai.assert.strictEqual(newState, 'foo');
+            });
+        });
+
+        it('should handle rejected promises', () => {
+            const bash = new Bash({
+                test: { exec: (state) => Promise.reject(new Error('foo')) }
+            });
+
+            const testCase = bash.execute('test', mockState);
+            return testCase.then((newState) => {
+                const { history } = newState;
+                chai.assert.strictEqual(history.length, 1);
+                chai.assert.strictEqual(history[0].value, 'foo');
+            });
+        });
+
         // Full command testing is in tests/command.js
         const commands = [
             { command: 'help' },

--- a/tests/bash.js
+++ b/tests/bash.js
@@ -74,8 +74,8 @@ describe('bash class methods', () => {
         });
 
         it('should handle fulfilled promises', () => {
-            const bash = new Bash({
-                test: { exec: (state) => Promise.resolve('foo') }
+            bash = new Bash({
+                test: { exec: () => Promise.resolve('foo') },
             });
 
             const testCase = bash.execute('test', {});
@@ -85,8 +85,8 @@ describe('bash class methods', () => {
         });
 
         it('should handle rejected promises', () => {
-            const bash = new Bash({
-                test: { exec: (state) => Promise.reject(new Error('foo')) }
+            bash = new Bash({
+                test: { exec: () => Promise.reject(new Error('foo')) },
             });
 
             const testCase = bash.execute('test', mockState);

--- a/tests/bash.js
+++ b/tests/bash.js
@@ -81,6 +81,7 @@ describe('bash class methods', () => {
             { command: 'cat', args: 'file1' },
             { command: 'mkdir', args: 'testDir' },
             { command: 'cd', args: 'dir1' },
+            { command: 'sleep', args: 0.1 },
         ];
 
         commands.forEach(data => {

--- a/tests/commands.js
+++ b/tests/commands.js
@@ -1,5 +1,4 @@
 import chai from 'chai';
-import sinon from 'sinon';
 import { stateFactory } from './factories';
 import Bash from '../src/bash';
 import * as BaseCommands from '../src/commands';

--- a/tests/commands.js
+++ b/tests/commands.js
@@ -1,4 +1,5 @@
 import chai from 'chai';
+import sinon from 'sinon';
 import { stateFactory } from './factories';
 import Bash from '../src/bash';
 import * as BaseCommands from '../src/commands';
@@ -358,6 +359,23 @@ describe('bash commands', () => {
             const { structure } = bash.commands.rm.exec(state, { args: { 0: 'dir1' }, flags: { R: true } });
             chai.assert.isUndefined(structure.dir1);
         });
+    });
+
+    describe('sleep', () => {
+
+        it('should exist', () => {
+            chai.assert.isFunction(bash.commands.sleep.exec);
+        });
+
+        it('should end after the given duration', () => {
+            const start = (new Date()).getTime();
+            const testCase = bash.commands.sleep.exec({}, { args: { 0: 0.25 } });
+            return testCase.then(() => {
+                const elapsed = (new Date()).getTime() - start;
+                chai.assert.isAtMost(elapsed, 300);
+            });
+        });
+
     });
 
 });

--- a/tests/component.js
+++ b/tests/component.js
@@ -94,7 +94,7 @@ describe('ReactBash component', () => {
         let instance;
 
         beforeEach(() => {
-            wrapper = shallow(<Terminal _observeBashExecutions={ true } />);
+            wrapper = shallow(<Terminal observeBashExecutions />);
             instance = wrapper.instance();
             instance.refs = { input: { value: '', scrollIntoView: () => {} } };
         });
@@ -118,7 +118,7 @@ describe('ReactBash component', () => {
             chai.assert.strictEqual(wrapper.state().history.length, 1);
             wrapper.find('input').simulate('keydown', keyEvent(17));
             wrapper.find('input').simulate('keyup', keyEvent(76));
-            return wrapper.state()._bashExecutionsObserver.then(() => {
+            return wrapper.state().bashExecutionsObserver.then(() => {
                 chai.assert.strictEqual(wrapper.state().history.length, 0);
             });
         });
@@ -168,7 +168,7 @@ describe('ReactBash component', () => {
         let bashStub;
 
         beforeEach(() => {
-            wrapper = shallow(<Terminal _observeBashExecutions={ true } />);
+            wrapper = shallow(<Terminal observeBashExecutions />);
             instance = wrapper.instance();
             instance.refs = { input: { value: 'Foo', scrollIntoView: () => {} } };
             bashStub = sinon.stub(instance.Bash, 'execute')
@@ -182,7 +182,7 @@ describe('ReactBash component', () => {
 
         it('should update state', () => {
             wrapper.find('form').simulate('submit', submitEvent('Foo'));
-            return wrapper.state()._bashExecutionsObserver.then(() => {
+            return wrapper.state().bashExecutionsObserver.then(() => {
                 chai.assert.strictEqual(wrapper.state().cwd, 'bar');
             });
         });

--- a/tests/component.js
+++ b/tests/component.js
@@ -94,7 +94,7 @@ describe('ReactBash component', () => {
         let instance;
 
         beforeEach(() => {
-            wrapper = shallow(<Terminal />);
+            wrapper = shallow(<Terminal _observeBashExecutions={ true } />);
             instance = wrapper.instance();
             instance.refs = { input: { value: '', scrollIntoView: () => {} } };
         });
@@ -118,7 +118,9 @@ describe('ReactBash component', () => {
             chai.assert.strictEqual(wrapper.state().history.length, 1);
             wrapper.find('input').simulate('keydown', keyEvent(17));
             wrapper.find('input').simulate('keyup', keyEvent(76));
-            chai.assert.strictEqual(wrapper.state().history.length, 0);
+            return wrapper.state()._bashExecutionsObserver.then(() => {
+                chai.assert.strictEqual(wrapper.state().history.length, 0);
+            });
         });
 
         it('should not clear on only l', () => {
@@ -166,10 +168,11 @@ describe('ReactBash component', () => {
         let bashStub;
 
         beforeEach(() => {
-            wrapper = shallow(<Terminal />);
+            wrapper = shallow(<Terminal _observeBashExecutions={ true } />);
             instance = wrapper.instance();
             instance.refs = { input: { value: 'Foo', scrollIntoView: () => {} } };
-            bashStub = sinon.stub(instance.Bash, 'execute').returns({ cwd: 'bar' });
+            bashStub = sinon.stub(instance.Bash, 'execute')
+                .returns(Promise.resolve({ cwd: 'bar' }));
         });
 
         it('should attempt to execute the command', () => {
@@ -179,7 +182,9 @@ describe('ReactBash component', () => {
 
         it('should update state', () => {
             wrapper.find('form').simulate('submit', submitEvent('Foo'));
-            chai.assert.strictEqual(wrapper.state().cwd, 'bar');
+            return wrapper.state()._bashExecutionsObserver.then(() => {
+                chai.assert.strictEqual(wrapper.state().cwd, 'bar');
+            });
         });
 
         it('should clear the input', () => {


### PR DESCRIPTION
This pull requests proposes to let commands return promises to handle long running tasks. As a result, it is possible to implement commands that doesn't return immediately (as shown with the added `sleep` command), as well as commands that would for instance fetch some data on a remote server.

The syntax and behaviour of the existing code barely changes. All existing commands remain unchanged, and it is possible to completely ignore the use of promises when writing extensions, if they are not needed. I just split the update of the terminal history from the command execution so the prompt can be hidden while long running commands are being executed. The result is unnoticeable for immediate commands, but introduces an additional state update. It shouldn't lead to performances issues though, as this happens only when the input is submitted. Internally, all command return values are promisified, but that shouldn't impact performances neither.

I also had to instrument the terminal component with an additional state property to handle asynchronous calls to `setState` during testing. This shouldn't have any impact outside of testing.