### PR TITLE
Implement multi-line cat

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -63,10 +63,10 @@ export const cat = {
         } else if (!dir[fileName].hasOwnProperty('content')) {
             return Util.appendError(state, Errors.IS_A_DIRECTORY, path);
         } else {
+            const content = dir[fileName].content.replace(/\n$/, '');
+            const lines = content.split('\n').map(value => ({ value }));
             return Object.assign({}, state, {
-                history: state.history.concat({
-                    value: dir[fileName].content,
-                }),
+                history: state.history.concat(lines),
             });
         }
     },

--- a/src/const.js
+++ b/src/const.js
@@ -13,7 +13,7 @@ export const Errors = {
 export const EnvVariables = {
     TERM_PROGRAM: 'ReactBash.app',
     TERM: 'reactbash-256color',
-    TERM_PROGRAM_VERSION: '1.4.3',
+    TERM_PROGRAM_VERSION: '1.6.0',
     TERM_SESSION_ID: 'w0t0p1:37842145-87D9-4768-BEC3-3684BAF3A964',
     USER: state => state.settings.user.username,
     PATH: '/',

--- a/tests/commands.js
+++ b/tests/commands.js
@@ -118,16 +118,16 @@ describe('bash commands', () => {
         });
 
         it('should display multiline file contents', () => {
-          const state = stateFactory();
-          const expected = [
-            'file2',
-            'hasfour',
-            'newlines',
-            ' ',
-          ];
-          const { history } = bash.commands.cat.exec(state, { args: { 0: 'multilinefile1' } });
-          chai.assert.strictEqual(history.length, 4);
-          chai.assert.deepEqual(history.map(h => h.value), expected);
+            const state = stateFactory();
+            const expected = [
+                'file2',
+                'hasfour',
+                'newlines',
+                ' ',
+            ];
+            const { history } = bash.commands.cat.exec(state, { args: { 0: 'multilinefile1' } });
+            chai.assert.strictEqual(history.length, 4);
+            chai.assert.deepEqual(history.map(h => h.value), expected);
         });
 
         it('should display file contents from path', () => {

--- a/tests/commands.js
+++ b/tests/commands.js
@@ -117,6 +117,19 @@ describe('bash commands', () => {
             chai.assert.strictEqual(history[0].value, expected);
         });
 
+        it('should display multiline file contents', () => {
+          const state = stateFactory();
+          const expected = [
+            'file2',
+            'hasfour',
+            'newlines',
+            ' ',
+          ];
+          const { history } = bash.commands.cat.exec(state, { args: { 0: 'multilinefile1' } });
+          chai.assert.strictEqual(history.length, 4);
+          chai.assert.deepEqual(history.map(h => h.value), expected);
+        });
+
         it('should display file contents from path', () => {
             const state = stateFactory();
             const expected = state.structure.dir1.dir1File.content;

--- a/tests/factories.js
+++ b/tests/factories.js
@@ -9,6 +9,7 @@ export function stateFactory(state = {}) {
             },
             '.privateFile': { content: 'Private File contents' },
             file1: { content: 'file1' },
+            multilinefile1: { content: 'file2\nhasfour\nnewlines\n \n'},
             dir1: {
                 childDir: {
                     childDirFile: { content: 'childDirFile' },

--- a/tests/factories.js
+++ b/tests/factories.js
@@ -9,7 +9,7 @@ export function stateFactory(state = {}) {
             },
             '.privateFile': { content: 'Private File contents' },
             file1: { content: 'file1' },
-            multilinefile1: { content: 'file2\nhasfour\nnewlines\n \n'},
+            multilinefile1: { content: 'file2\nhasfour\nnewlines\n \n' },
             dir1: {
                 childDir: {
                     childDirFile: { content: 'childDirFile' },


### PR DESCRIPTION
Split the input field on newlines, and push a new history state for each newline. If there is a final \n, then ignore it.